### PR TITLE
Fix 'neve' paths for case-sensitive filesystems

### DIFF
--- a/SumChannel (Tukan)
+++ b/SumChannel (Tukan)
@@ -84,7 +84,7 @@ slider64:0.5<0,1,0.1>-38 Balance
 
 filename:0,sumchan/screw.png
 filename:1,sumchan/chick60.png
-filename:2,sumchan/neve60.png
+filename:2,sumchan/Neve60.png
 filename:3,sumchan/ssl60.png
 filename:4,sumchan/switch.png
 filename:5,sumchan/VUMeter1.png
@@ -111,8 +111,8 @@ filename:23,sumchan/sslg60.png
 filename:24,sumchan/sslb60.png
 filename:25,sumchan/ssll60.png
 
-filename:26,sumchan/neveb60.png
-filename:27,sumchan/never60.png
+filename:26,sumchan/Neveb60.png
+filename:27,sumchan/Never60.png
 
 options:No_meter
 


### PR DESCRIPTION
Reaper on linux couldn't find the 'neve' style knobs because the case
was off. Given the default filesystems under UNIX are case-sensitive,
this is hardly surprising. Fix case: neve -> Neve to match the
distributed graphics.